### PR TITLE
設定していなかったapiBaseUrlを指定

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,8 +10,8 @@ on:
   schedule:
     - cron: "0 1 * * *"
   push:
-    # branches:
-      # - master
+    branches:
+      - master
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,8 +10,8 @@ on:
   schedule:
     - cron: "0 1 * * *"
   push:
-    branches:
-      - master
+    # branches:
+      # - master
   workflow_dispatch:
 jobs:
   release:

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -31,6 +31,7 @@ sites:
   - name: Registry (Internal)
     url: $SECRET_SITE
 assignees:
+  - camphor-bot
 status-website:
   cname: status.camph.net
   logoUrl: https://raw.githubusercontent.com/camphor-/status/master/camphor_logo.svg

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -30,6 +30,7 @@ sites:
     url: https://relaym-api.camph.net/api/v3/sessions/06b7db29-b1d7-4ae7-bfdf-ddaf0f4274c3
   - name: Registry (Internal)
     url: $SECRET_SITE
+assignees:
 status-website:
   cname: status.camph.net
   logoUrl: https://raw.githubusercontent.com/camphor-/status/master/camphor_logo.svg

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -31,7 +31,6 @@ sites:
   - name: Registry (Internal)
     url: $SECRET_SITE
 assignees:
-  - camphor-bot
 status-website:
   cname: status.camph.net
   logoUrl: https://raw.githubusercontent.com/camphor-/status/master/camphor_logo.svg

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -36,6 +36,7 @@ status-website:
   cname: status.camph.net
   logoUrl: https://raw.githubusercontent.com/camphor-/status/master/camphor_logo.svg
   name: CAMPHOR- Status
+  apiBaseUrl: https://api.github.com
   introTitle: "**CAMPHOR- Status** ではCAMPHOR-が運営しているサービスの状態をチェックしています。"
   introMessage: 
 notifications:

--- a/history/account.yml
+++ b/history/account.yml
@@ -1,7 +1,7 @@
 - url: https://account.camph.net
 - status: down
 - code: 502
-- responseTime: 604
-- lastUpdated: 2020-11-17T03:48:48.761Z
+- responseTime: 701
+- lastUpdated: 2020-11-17T04:24:29.990Z
 - startTime: 2020-10-23T14:15:08.825Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/account.yml
+++ b/history/account.yml
@@ -1,7 +1,7 @@
 - url: https://account.camph.net
 - status: down
 - code: 502
-- responseTime: 562
-- lastUpdated: 2020-11-17T03:35:41.273Z
+- responseTime: 604
+- lastUpdated: 2020-11-17T03:48:48.761Z
 - startTime: 2020-10-23T14:15:08.825Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/advent.yml
+++ b/history/advent.yml
@@ -1,7 +1,7 @@
 - url: https://advent.camph.net
 - status: up
 - code: 200
-- responseTime: 1043
-- lastUpdated: 2020-11-17T03:48:50.090Z
+- responseTime: 1046
+- lastUpdated: 2020-11-17T04:24:31.332Z
 - startTime: 2020-10-23T14:15:11.055Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/advent.yml
+++ b/history/advent.yml
@@ -1,7 +1,7 @@
 - url: https://advent.camph.net
 - status: up
 - code: 200
-- responseTime: 1058
-- lastUpdated: 2020-11-17T03:35:42.575Z
+- responseTime: 1043
+- lastUpdated: 2020-11-17T03:48:50.090Z
 - startTime: 2020-10-23T14:15:11.055Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/blog.yml
+++ b/history/blog.yml
@@ -1,7 +1,7 @@
 - url: https://blog.camph.net
 - status: up
 - code: 200
-- responseTime: 2148
-- lastUpdated: 2020-11-17T03:48:52.537Z
+- responseTime: 1864
+- lastUpdated: 2020-11-17T04:24:33.481Z
 - startTime: 2020-10-23T14:15:15.815Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/blog.yml
+++ b/history/blog.yml
@@ -1,7 +1,7 @@
 - url: https://blog.camph.net
 - status: up
 - code: 200
-- responseTime: 1201
-- lastUpdated: 2020-11-17T03:35:44.022Z
+- responseTime: 2148
+- lastUpdated: 2020-11-17T03:48:52.537Z
 - startTime: 2020-10-23T14:15:15.815Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/books.yml
+++ b/history/books.yml
@@ -1,7 +1,7 @@
 - url: https://books.camph.net
 - status: up
 - code: 200
-- responseTime: 538
-- lastUpdated: 2020-11-17T03:48:47.502Z
+- responseTime: 581
+- lastUpdated: 2020-11-17T04:24:28.608Z
 - startTime: 2020-10-23T14:15:06.785Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/books.yml
+++ b/history/books.yml
@@ -1,7 +1,7 @@
 - url: https://books.camph.net
 - status: up
 - code: 200
-- responseTime: 562
-- lastUpdated: 2020-11-17T03:35:40.098Z
+- responseTime: 538
+- lastUpdated: 2020-11-17T03:48:47.502Z
 - startTime: 2020-10-23T14:15:06.785Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/calendar.yml
+++ b/history/calendar.yml
@@ -1,7 +1,7 @@
 - url: https://cal.camph.net
 - status: up
 - code: 200
-- responseTime: 552
-- lastUpdated: 2020-11-17T03:48:54.808Z
+- responseTime: 527
+- lastUpdated: 2020-11-17T04:24:35.791Z
 - startTime: 2020-10-23T14:15:21.720Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/calendar.yml
+++ b/history/calendar.yml
@@ -1,7 +1,7 @@
 - url: https://cal.camph.net
 - status: up
 - code: 200
-- responseTime: 572
-- lastUpdated: 2020-11-17T03:35:46.225Z
+- responseTime: 552
+- lastUpdated: 2020-11-17T03:48:54.808Z
 - startTime: 2020-10-23T14:15:21.720Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/feeds.yml
+++ b/history/feeds.yml
@@ -1,7 +1,7 @@
 - url: https://feeds.camph.net/public/feeds.json
 - status: up
 - code: 200
-- responseTime: 874
-- lastUpdated: 2020-11-17T03:35:47.377Z
+- responseTime: 861
+- lastUpdated: 2020-11-17T03:48:55.965Z
 - startTime: 2020-10-23T14:15:23.580Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/feeds.yml
+++ b/history/feeds.yml
@@ -1,7 +1,7 @@
 - url: https://feeds.camph.net/public/feeds.json
 - status: up
 - code: 200
-- responseTime: 861
-- lastUpdated: 2020-11-17T03:48:55.965Z
+- responseTime: 915
+- lastUpdated: 2020-11-17T04:24:36.986Z
 - startTime: 2020-10-23T14:15:23.580Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/house.yml
+++ b/history/house.yml
@@ -1,7 +1,7 @@
 - url: https://house.camph.net
 - status: up
 - code: 200
-- responseTime: 535
-- lastUpdated: 2020-11-17T03:35:48.173Z
+- responseTime: 523
+- lastUpdated: 2020-11-17T03:48:56.772Z
 - startTime: 2020-10-23T14:15:26.409Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/house.yml
+++ b/history/house.yml
@@ -1,7 +1,7 @@
 - url: https://house.camph.net
 - status: up
 - code: 200
-- responseTime: 523
-- lastUpdated: 2020-11-17T03:48:56.772Z
+- responseTime: 527
+- lastUpdated: 2020-11-17T04:24:37.796Z
 - startTime: 2020-10-23T14:15:26.409Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/ipsj.yml
+++ b/history/ipsj.yml
@@ -1,7 +1,7 @@
 - url: http://ipsj.camph.net/
 - status: up
 - code: 200
-- responseTime: 871
-- lastUpdated: 2020-11-17T03:48:57.943Z
+- responseTime: 874
+- lastUpdated: 2020-11-17T04:24:38.970Z
 - startTime: 2020-10-23T14:29:20.090Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/ipsj.yml
+++ b/history/ipsj.yml
@@ -1,7 +1,7 @@
 - url: http://ipsj.camph.net/
 - status: up
 - code: 200
-- responseTime: 882
-- lastUpdated: 2020-11-17T03:35:49.308Z
+- responseTime: 871
+- lastUpdated: 2020-11-17T03:48:57.943Z
 - startTime: 2020-10-23T14:29:20.090Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/jinrou.yml
+++ b/history/jinrou.yml
@@ -1,7 +1,7 @@
 - url: http://jinrou.camph.net
 - status: up
 - code: 200
-- responseTime: 914
-- lastUpdated: 2020-11-17T03:35:50.488Z
+- responseTime: 868
+- lastUpdated: 2020-11-17T03:48:59.104Z
 - startTime: 2020-10-23T14:15:31.606Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/jinrou.yml
+++ b/history/jinrou.yml
@@ -1,7 +1,7 @@
 - url: http://jinrou.camph.net
 - status: up
 - code: 200
-- responseTime: 868
-- lastUpdated: 2020-11-17T03:48:59.104Z
+- responseTime: 894
+- lastUpdated: 2020-11-17T04:24:40.153Z
 - startTime: 2020-10-23T14:15:31.606Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/python-tutorial.yml
+++ b/history/python-tutorial.yml
@@ -1,7 +1,7 @@
 - url: http://python-tutorial.camph.net
 - status: up
 - code: 200
-- responseTime: 1377
-- lastUpdated: 2020-11-17T03:49:00.773Z
+- responseTime: 1564
+- lastUpdated: 2020-11-17T04:24:42.020Z
 - startTime: 2020-10-23T14:15:34.507Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/python-tutorial.yml
+++ b/history/python-tutorial.yml
@@ -1,7 +1,7 @@
 - url: http://python-tutorial.camph.net
 - status: up
 - code: 200
-- responseTime: 1565
-- lastUpdated: 2020-11-17T03:35:52.302Z
+- responseTime: 1377
+- lastUpdated: 2020-11-17T03:49:00.773Z
 - startTime: 2020-10-23T14:15:34.507Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/registry-internal.yml
+++ b/history/registry-internal.yml
@@ -1,7 +1,7 @@
 - url: $SECRET_SITE
 - status: up
 - code: 200
-- responseTime: 532
-- lastUpdated: 2020-11-17T03:49:02.560Z
+- responseTime: 551
+- lastUpdated: 2020-11-17T04:24:43.810Z
 - startTime: 2020-10-23T16:46:54.539Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/registry-internal.yml
+++ b/history/registry-internal.yml
@@ -1,7 +1,7 @@
 - url: $SECRET_SITE
 - status: up
 - code: 200
-- responseTime: 533
-- lastUpdated: 2020-11-17T03:35:53.959Z
+- responseTime: 532
+- lastUpdated: 2020-11-17T03:49:02.560Z
 - startTime: 2020-10-23T16:46:54.539Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/relaym-api-prod.yml
+++ b/history/relaym-api-prod.yml
@@ -1,7 +1,7 @@
 - url: https://relaym-api.camph.net/api/v3/sessions/06b7db29-b1d7-4ae7-bfdf-ddaf0f4274c3
 - status: up
 - code: 200
-- responseTime: 641
-- lastUpdated: 2020-11-17T03:49:01.713Z
+- responseTime: 664
+- lastUpdated: 2020-11-17T04:24:42.969Z
 - startTime: 2020-10-23T14:15:39.879Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/relaym-api-prod.yml
+++ b/history/relaym-api-prod.yml
@@ -1,7 +1,7 @@
 - url: https://relaym-api.camph.net/api/v3/sessions/06b7db29-b1d7-4ae7-bfdf-ddaf0f4274c3
 - status: up
 - code: 200
-- responseTime: 607
-- lastUpdated: 2020-11-17T03:35:53.165Z
+- responseTime: 641
+- lastUpdated: 2020-11-17T03:49:01.713Z
 - startTime: 2020-10-23T14:15:39.879Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/tech-blog.yml
+++ b/history/tech-blog.yml
@@ -1,7 +1,7 @@
 - url: https://tech.camph.net
 - status: up
 - code: 200
-- responseTime: 1120
-- lastUpdated: 2020-11-17T03:48:53.963Z
+- responseTime: 1195
+- lastUpdated: 2020-11-17T04:24:34.968Z
 - startTime: 2020-10-23T14:15:18.687Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/tech-blog.yml
+++ b/history/tech-blog.yml
@@ -1,7 +1,7 @@
 - url: https://tech.camph.net
 - status: up
 - code: 200
-- responseTime: 1097
-- lastUpdated: 2020-11-17T03:35:45.391Z
+- responseTime: 1120
+- lastUpdated: 2020-11-17T03:48:53.963Z
 - startTime: 2020-10-23T14:15:18.687Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/website.yml
+++ b/history/website.yml
@@ -1,7 +1,7 @@
 - url: https://camph.net
 - status: up
 - code: 200
-- responseTime: 919
-- lastUpdated: 2020-11-17T03:48:46.642Z
+- responseTime: 946
+- lastUpdated: 2020-11-17T04:24:27.730Z
 - startTime: 2020-10-23T14:15:04.487Z
 - generator: Upptime <https://github.com/upptime/upptime>

--- a/history/website.yml
+++ b/history/website.yml
@@ -1,7 +1,7 @@
 - url: https://camph.net
 - status: up
 - code: 200
-- responseTime: 914
-- lastUpdated: 2020-11-17T03:35:39.275Z
+- responseTime: 919
+- lastUpdated: 2020-11-17T03:48:46.642Z
 - startTime: 2020-10-23T14:15:04.487Z
 - generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Why
status.camph.net が500になってしまった。

uptimeのmasterにbreaking changneが入っている。
以下のコードで `apiBaseUrl.includes("api.github.com")` をしてるんだけど、この `apiBaseUrl`は
`const { apiBaseUrl } = config["status-website"];` で取ってる。
https://github.com/upptime/status-page/blob/4c011ceeafee7748aa5a914816e99426328a3b46/src/components/LiveStatus.svelte#L14

がuptimerc.yamlに apiBaseUrlは設定されてないので、undefinedに対してincludesにしようとしてエラーになってる

## What
- `apiBaseUrl` を設定
- `assignees` を空にする
  - interface 的にundefinedにするのはまずそうなので
  - https://github.com/upptime/uptime-monitor/blob/master/src/interfaces.ts#L13
